### PR TITLE
DTSPO-242 - separate frontdoor and app gw pipelines

### DIFF
--- a/azure-pipelines-frontdoor.yaml
+++ b/azure-pipelines-frontdoor.yaml
@@ -45,7 +45,7 @@ variables:
   - name: timeoutInMinutes
     value: '360'
   - name: agentPool
-    value: 'hmcts-agent-pool'
+    value: 'hmcts-cftptl-agent-pool'
   - name: build
     value: $(Build.BuildNumber)
   - name: isMaster

--- a/azure-pipelines-frontdoor.yaml
+++ b/azure-pipelines-frontdoor.yaml
@@ -1,4 +1,4 @@
-name: SDS Azure Platform
+name: SDS Azure Platform - frontdoor
 trigger:
   batch: true
   branches:
@@ -10,22 +10,22 @@ parameters:
     displayName: Component to Run
     type: object
     default:
-      - deployment: 'appgateway'
+      - deployment: 'frontdoor'
         environment: 'sbox'
         dependsOn: 'Precheck'
-      - deployment: 'appgateway'
+      - deployment: 'frontdoor'
         environment: 'dev'
         dependsOn: 'Precheck'
-      - deployment: 'appgateway'
+      - deployment: 'frontdoor'
         environment: 'stg'
         dependsOn: 'Precheck'
-      - deployment: 'appgateway'
+      - deployment: 'frontdoor'
         environment: 'ithc'
         dependsOn: 'Precheck'
-      - deployment: 'appgateway'
+      - deployment: 'frontdoor'
         environment: 'test'
         dependsOn: 'Precheck'
-      - deployment: 'appgateway'
+      - deployment: 'frontdoor'
         environment: 'prod'
         dependsOn: 'Precheck'
 
@@ -43,7 +43,7 @@ variables:
   - name: project
     value: application
   - name: timeoutInMinutes
-    value: '60'
+    value: '360'
   - name: agentPool
     value: 'ubuntu-18.04'
   - name: build

--- a/azure-pipelines-frontdoor.yaml
+++ b/azure-pipelines-frontdoor.yaml
@@ -100,7 +100,7 @@ stages:
         jobs:
           - job:
             pool:
-              vmImage: 'ubuntu-16.04'
+              vmImage: ${{ variables.agentPool }}
             steps:
               - template: pipeline-templates/terraform.yaml
                 parameters:

--- a/azure-pipelines-frontdoor.yaml
+++ b/azure-pipelines-frontdoor.yaml
@@ -58,7 +58,7 @@ stages:
       - job: Validate
         timeoutInMinutes: ${{ variables.timeoutInMinutes }}
         pool:
-          vmImage: ${{ variables.agentPool }}
+          name: ${{ variables.agentPool }}
         steps:
         - task: TerraformInstaller@0
           displayName: Terraform install
@@ -100,7 +100,7 @@ stages:
         jobs:
           - job:
             pool:
-              vmImage: ${{ variables.agentPool }}
+              name: ${{ variables.agentPool }}
             steps:
               - template: pipeline-templates/terraform.yaml
                 parameters:

--- a/azure-pipelines-frontdoor.yaml
+++ b/azure-pipelines-frontdoor.yaml
@@ -45,7 +45,7 @@ variables:
   - name: timeoutInMinutes
     value: '360'
   - name: agentPool
-    value: 'hmcts-cftptl-agent-pool'
+    value: 'hmcts-agent-pool'
   - name: build
     value: $(Build.BuildNumber)
   - name: isMaster

--- a/azure-pipelines-frontdoor.yaml
+++ b/azure-pipelines-frontdoor.yaml
@@ -45,7 +45,7 @@ variables:
   - name: timeoutInMinutes
     value: '360'
   - name: agentPool
-    value: 'ubuntu-18.04'
+    value: 'hmcts-cftptl-agent-pool'
   - name: build
     value: $(Build.BuildNumber)
   - name: isMaster

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -101,7 +101,7 @@ stages:
         jobs:
           - job:
             pool:
-              vmImage: 'ubuntu-16.04'
+              vmImage: ${{ variables.agentPool }}
             steps:
               - template: pipeline-templates/terraform.yaml
                 parameters:

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -97,6 +97,7 @@ stages:
   - ${{ each parameter in parameters.components }}:
       - stage: ${{ parameter.environment }}_${{ parameter.deployment }}
         displayName: ${{ parameter.environment }}_${{ parameter.deployment }}
+        dependsOn: ${{ parameter.dependsOn }}
         jobs:
           - job:
             pool:


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-242


### Change description ###
Moving frontdoor deployment to separate pipeline until the sorting is fixed. 

Pipeline name is current "SDS Azure Platform - frontdoor" let me know if it should be something different. 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
