### PR TITLE
DTSPO-658 Exclude Env Name in App Name

### DIFF
--- a/environments/ithc/backend_lb_config.yaml
+++ b/environments/ithc/backend_lb_config.yaml
@@ -5,6 +5,7 @@ gateways:
       host_name_suffix: ithc.platform.hmcts.net
       ssl_host_name_suffix: ithc.platform.hmcts.net
       certificate_name: wildcard-ithc-platform-hmcts-net
+      exclude_env_in_app_name: true
     app_configuration:
     # Toffee
       - product: toffee

--- a/environments/prod/backend_lb_config.yaml
+++ b/environments/prod/backend_lb_config.yaml
@@ -5,6 +5,7 @@ gateways:
       host_name_suffix: platform.hmcts.net
       ssl_host_name_suffix: platform.hmcts.net
       certificate_name: wildcard-platform-hmcts-net
+      exclude_env_in_app_name: true
     app_configuration:
   # Toffee
       - product: toffee

--- a/environments/sbox/backend_lb_config.yaml
+++ b/environments/sbox/backend_lb_config.yaml
@@ -5,6 +5,7 @@ gateways:
       host_name_suffix: sandbox.platform.hmcts.net
       ssl_host_name_suffix: sandbox.platform.hmcts.net
       certificate_name: STAR-sandbox-platform-hmcts-net
+      exclude_env_in_app_name: true
     app_configuration:
     # Toffee
       - product: toffee

--- a/environments/stg/backend_lb_config.yaml
+++ b/environments/stg/backend_lb_config.yaml
@@ -5,6 +5,7 @@ gateways:
       host_name_suffix: staging.platform.hmcts.net
       ssl_host_name_suffix: staging.platform.hmcts.net
       certificate_name: wildcard-staging-platform-hmcts-net
+      exclude_env_in_app_name: true
     app_configuration:
     # Toffee
       - product: toffee

--- a/environments/test/backend_lb_config.yaml
+++ b/environments/test/backend_lb_config.yaml
@@ -5,6 +5,7 @@ gateways:
       host_name_suffix: test.platform.hmcts.net
       ssl_host_name_suffix: test.platform.hmcts.net
       certificate_name: wildcard-test-platform-hmcts-net
+      exclude_env_in_app_name: true
     app_configuration:
     # Toffee
       - product: toffee


### PR DESCRIPTION
### JIRA link ###
https://tools.hmcts.net/jira/browse/DTSPO-658


### Change description ###
Exclude the environment name in the app name, so that the domains will appear as e.g. 
'toffee-recipe-backend.staging.platform.hmcts.net' instead of 'toffee-recipe-backend-stg.staging.platform.hmcts.net'
**Does this PR introduce a breaking change?**

```
[ ] Yes
[x] No
```
